### PR TITLE
new cmf module

### DIFF
--- a/modules/cmf/build.gradle
+++ b/modules/cmf/build.gradle
@@ -1,0 +1,12 @@
+description = 'jPOS-EE :: CMF Utils'
+
+dependencies {
+    api libraries.jpos
+    api libraries.commons_lang
+
+    testImplementation libraries.junit
+}
+
+
+apply from: "${rootProject.projectDir}/jpos-app.gradle"
+

--- a/modules/cmf/src/main/java/org/jpos/cmf/AdditionalAmount.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/AdditionalAmount.java
@@ -1,0 +1,129 @@
+package org.jpos.cmf;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@SuppressWarnings("WeakerAccess")
+public class AdditionalAmount {
+
+    public final static int SERIALIZED_DATA_LENGTH = 21;
+
+    private String accountType;
+    private AmountType amountType;
+    private BigDecimal amount;
+    private String currencyCode;
+    private int currencyMinorUnit;
+
+    public AdditionalAmount(String accountType, BigDecimal amount, String currencyCode,
+                            AmountType amountType, int currencyMinorUnit) {
+
+        setAccountType(accountType);
+        setAmount(amount);
+        setCurrencyCode(currencyCode);
+        setAmountType(amountType);
+        setCurrencyMinorUnit(currencyMinorUnit);
+    }
+
+    public String getAccountType() {
+        return accountType;
+    }
+
+    public void setAccountType(String accountType) {
+
+        Objects.requireNonNull(accountType);
+
+        if (accountType.length() != 2)
+            throw new IllegalArgumentException("Invalid account type length");
+
+        this.accountType = accountType;
+    }
+
+    public AmountType getAmountType() {
+        return amountType;
+    }
+
+    public void setAmountType(AmountType amountType) {
+        Objects.requireNonNull(amountType);
+        this.amountType = amountType;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        Objects.requireNonNull(amount);
+        this.amount = amount;
+    }
+
+    public String getCurrencyCode() {
+        return currencyCode;
+    }
+
+    public void setCurrencyCode(String currencyCode) {
+
+        Objects.requireNonNull(currencyCode);
+
+        if (currencyCode.length() != 3)
+            throw new IllegalArgumentException("Invalid currency code");
+
+        this.currencyCode = currencyCode;
+    }
+
+    public int getCurrencyMinorUnit() {
+        return currencyMinorUnit;
+    }
+
+    public void setCurrencyMinorUnit(int currencyMinorUnit) {
+
+        if (currencyMinorUnit < 0 || currencyMinorUnit > 9)
+            throw new IllegalArgumentException("Invalid currency minor unit value");
+
+        this.currencyMinorUnit = currencyMinorUnit;
+    }
+
+    public String serialize() {
+        if (getAmountType() == null)
+            throw new IllegalStateException("Amount type not set");
+
+        if (getAmount() == null)
+            throw new IllegalStateException("Amount not set");
+
+        long absAmt= getAmount().movePointRight(getCurrencyMinorUnit()).abs().longValue();
+
+        @SuppressWarnings("StringBufferReplaceableByString")
+        StringBuilder sb = new StringBuilder();
+        sb.append(getAccountType());
+        sb.append(getAmountType().toString());
+        sb.append(getCurrencyCode());
+        sb.append(getCurrencyMinorUnit());
+        sb.append(getAmount().compareTo(BigDecimal.ZERO) >= 0 ? "C" : "D");
+        sb.append(StringUtils.leftPad(Long.toString(absAmt), 12, '0'));
+
+        return sb.toString();
+    }
+
+    static AdditionalAmount parse(String data) {
+        Objects.requireNonNull(data);
+
+        if (data.length() != SERIALIZED_DATA_LENGTH)
+            throw new IllegalArgumentException("Invalid data length");
+
+        String accountType = StringUtils.mid(data, 0, 2);
+        AmountType amountType = AmountType.fromCode(StringUtils.mid(data, 2, 2));
+        String currencyCode = StringUtils.mid(data, 4, 3);
+        int minorUnit = Integer.parseInt(StringUtils.mid(data, 7, 1));
+        BigDecimal amount = new BigDecimal(StringUtils.right(data, 12)).movePointLeft(minorUnit);
+        String amountSign = StringUtils.mid(data, 8, 1);
+
+        if (!"C.D".contains(amountSign))
+            throw new IllegalArgumentException("Invalid amount sign");
+
+        if ("D".equalsIgnoreCase(amountSign))
+            amount = amount.negate();
+
+        return new AdditionalAmount(accountType, amount, currencyCode, amountType, minorUnit);
+    }
+}

--- a/modules/cmf/src/main/java/org/jpos/cmf/AdditionalAmountsWrapper.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/AdditionalAmountsWrapper.java
@@ -75,7 +75,6 @@ public final class AdditionalAmountsWrapper extends LinkedHashSet<AdditionalAmou
     }
 
 
-
     /**
      * Returns the first occurrence of the additional amount that matches the filter criteria.
      *
@@ -104,6 +103,5 @@ public final class AdditionalAmountsWrapper extends LinkedHashSet<AdditionalAmou
         Objects.requireNonNull(amountType);
         return listByTypes(null, amountType);
     }
-
 
 }

--- a/modules/cmf/src/main/java/org/jpos/cmf/AdditionalAmountsWrapper.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/AdditionalAmountsWrapper.java
@@ -1,0 +1,109 @@
+package org.jpos.cmf;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Handles additional amounts field content - DE-054
+ */
+public final class AdditionalAmountsWrapper extends LinkedHashSet<AdditionalAmount> {
+
+    private static final long serialVersionUID = 2526355280704001241L;
+
+    public static AdditionalAmountsWrapper parse(String data) {
+        if (data.length() % AdditionalAmount.SERIALIZED_DATA_LENGTH != 0)
+            throw new IllegalArgumentException("Invalid length");
+
+        AdditionalAmountsWrapper amounts = new AdditionalAmountsWrapper();
+        int i = 0;
+
+        while (i < data.length()) {
+            AdditionalAmount amount = AdditionalAmount.parse(
+                    StringUtils.mid(data, i, AdditionalAmount.SERIALIZED_DATA_LENGTH));
+
+            amounts.add(amount);
+
+            i += AdditionalAmount.SERIALIZED_DATA_LENGTH;
+        }
+
+        return amounts;
+    }
+
+    public String serialize() {
+        StringBuilder sb = new StringBuilder();
+        forEach(amount -> sb.append(amount.serialize()));
+        return sb.toString();
+    }
+
+
+    /**
+     * Returns a list of the additional amounts that match the filter criteria.
+     *
+     * If one of the filters is null, it's not considered in the criteria.
+     *
+     * @param accountType the account type to filter amounts by.
+     * @param amountType the amount type to filter amounts by.
+     * @return a list of the additional amounts that match the filter criteria.
+     */
+    public List<AdditionalAmount> listByTypes(String accountType, AmountType amountType) {
+        ArrayList<AdditionalAmount> amounts = new ArrayList<>();
+        for (AdditionalAmount amount : this) {
+            if ((accountType == null || amount.getAccountType().equals(accountType)) &&
+                (amountType  == null || amount.getAmountType() == amountType)) {
+                amounts.add(amount);
+            }
+        }
+
+        return amounts;
+    }
+
+
+    /**
+     * Returns true when the wrapper has the given {@code amountType}.
+     *
+     * @param amountType the amount type.
+     * @return true when the wrapper has the given {@code amountType}.
+     * @throws NullPointerException if {@code amountType} is {@code null}
+     */
+    public boolean containsAmountType(AmountType amountType) {
+        Objects.requireNonNull(amountType);
+        return getFirstByAmountType(amountType) != null;
+    }
+
+
+
+    /**
+     * Returns the first occurrence of the additional amount that matches the filter criteria.
+     *
+     * @param amountType the amount type to filter amounts by
+     * @return the first occurrence of the additional amount that matches the filter criteria, or null if none matches
+     * @throws NullPointerException if {@code amountType} is {@code null}
+     */
+    public AdditionalAmount getFirstByAmountType(AmountType amountType) {
+        Objects.requireNonNull(amountType);
+        for (AdditionalAmount addAmnt : this) {
+            if (addAmnt.getAmountType().equals(amountType))
+                return addAmnt;
+        }
+        return null;
+    }
+
+
+    /**
+     * Returns a list of the additional amounts that match the filter criteria.
+     *
+     * @param amountType the amount type to filter amounts by.
+     * @return a list of the additional amounts that match the filter criteria.
+     * @throws NullPointerException if {@code amountType} is {@code null}
+     */
+    public List<AdditionalAmount> listByAmountType(AmountType amountType) {
+        Objects.requireNonNull(amountType);
+        return listByTypes(null, amountType);
+    }
+
+
+}

--- a/modules/cmf/src/main/java/org/jpos/cmf/AmountFee.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/AmountFee.java
@@ -1,0 +1,122 @@
+package org.jpos.cmf;
+
+import org.jpos.iso.ISOUtil;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.math.RoundingMode;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A single Fee amount, from jPOS-CMF DE-046<br>
+ *
+ * Format:  FeeType + fee amount + conversion rate + settlement fee (N2, N13, N8, N13)
+ *
+ * @see AmountFeesWrapper
+ * @see FeeType
+ * @see CMFAmount
+ */
+public class AmountFee {
+    protected final static int SERIALIZED_DATA_LENGTH = 36;
+    protected static final MathContext RATE_PRECISION = new MathContext(7, RoundingMode.HALF_EVEN);
+
+    protected FeeType feeType;
+    protected CMFAmount fee;
+    protected CMFAmount settlementFee;
+    protected BigDecimal conversionRate;
+
+    public AmountFee(FeeType feeType, CMFAmount fee, CMFAmount settlementFee, BigDecimal conversionRate) {
+        setFeeType(feeType);
+        setFee(fee);
+        setSettlementFee(settlementFee);
+        setConversionRate(conversionRate);
+        if (conversionRate == null) throw new IllegalArgumentException("null conversionRate");
+//        calculateConversionRate();
+    }
+
+    public AmountFee(FeeType feeType, CMFAmount fee, CMFAmount settlementFee, String conversionRate) {
+        setFeeType(feeType);
+        setFee(fee);
+        setSettlementFee(settlementFee);
+        setConversionRate(conversionRate);
+        if (conversionRate == null) throw new IllegalArgumentException("null conversionRate");
+//        calculateConversionRate();
+    }
+
+    public AmountFee(String data) {
+        if (data.length() != SERIALIZED_DATA_LENGTH) throw new IllegalArgumentException("Invalid data length");
+        feeType = FeeType.fromCode(data.substring(0, 2));
+        fee = new CMFAmount(data.substring(2, 15));
+        setConversionRate(data.substring(15, 23));
+        settlementFee = new CMFAmount(data.substring(23));
+    }
+
+    public FeeType getFeeType() {
+        return feeType;
+    }
+
+    public void setFeeType(FeeType feeType) {
+        this.feeType = requireNonNull(feeType);
+    }
+
+    public CMFAmount getFee() {
+        return fee;
+    }
+
+    public void setFee(CMFAmount fee) {
+        this.fee = requireNonNull(fee);
+    }
+
+    public CMFAmount getSettlementFee() {
+        return settlementFee;
+    }
+
+    public void setSettlementFee(CMFAmount settlementFee) {
+        this.settlementFee = requireNonNull(settlementFee);
+    }
+
+    public BigDecimal getConversionRate() {
+        return conversionRate;
+    }
+
+    public void setConversionRate(BigDecimal conversionRate) {
+        // BBB: what if the value has more than 7 significant digits (precision)?
+        //      should we round the value or reject it?
+        this.conversionRate = requireNonNull(conversionRate);
+    }
+
+    public void setConversionRate(String conversionRate) {
+        if (conversionRate != null) {
+            // Conversion rate is N8, where first digit moves the decimal point to the left
+            // But: ISO8583-1:2003 "6.2.4 Conversion rates"
+            //    If the value of the first digit is 8, a single zero after the decimal point is assumed.
+            //    If the value of the first digit is 9, two zeroes after the decimal point are assumed.
+            int conversionScale = conversionRate.charAt(0) - '0';
+            if (conversionScale == 8 || conversionScale == 9)
+                conversionScale++;
+            setConversionRate(new BigDecimal(new BigInteger(conversionRate.substring(1)), conversionScale));
+        }
+    }
+
+    public String serialize() {
+        // TODO: 1. Correctly serialize for cases with with high decimal counts
+        //       ----
+        //       2. Maybe we should check that the (unscaled) value has no more than 7 digits?
+        //         Should we round, fail?
+        return feeType.getCode() +
+                fee.serialize() +
+                conversionRate.scale() + ISOUtil.zeropad(conversionRate.unscaledValue().intValue(), 7) +
+                settlementFee.serialize();
+    }
+
+    // BBB comment on the RATE_PRECISION: currently == MathContext(7, RoundingMode.HALF_EVEN)
+    //     This is for the rare cases where the conversionRate has not been made explicit in the constructors.
+    //     Another alternative: Eliminate this method and DON'T ALLOW the construction of this object with a null conversion rate!
+    protected void calculateConversionRate() {
+        if (conversionRate == null)
+            conversionRate = settlementFee.getAmount().divide(fee.getAmount(), RATE_PRECISION);
+    }
+
+}

--- a/modules/cmf/src/main/java/org/jpos/cmf/AmountFee.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/AmountFee.java
@@ -31,18 +31,18 @@ public class AmountFee {
         setFeeType(feeType);
         setFee(fee);
         setSettlementFee(settlementFee);
-        setConversionRate(conversionRate);
         if (conversionRate == null) throw new IllegalArgumentException("null conversionRate");
 //        calculateConversionRate();
+        setConversionRate(conversionRate);
     }
 
     public AmountFee(FeeType feeType, CMFAmount fee, CMFAmount settlementFee, String conversionRate) {
         setFeeType(feeType);
         setFee(fee);
         setSettlementFee(settlementFee);
-        setConversionRate(conversionRate);
         if (conversionRate == null) throw new IllegalArgumentException("null conversionRate");
 //        calculateConversionRate();
+        setConversionRate(conversionRate);
     }
 
     public AmountFee(String data) {

--- a/modules/cmf/src/main/java/org/jpos/cmf/AmountFeesWrapper.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/AmountFeesWrapper.java
@@ -1,0 +1,31 @@
+package org.jpos.cmf;
+
+import java.util.LinkedList;
+import java.util.stream.Collectors;
+
+
+/**
+ * Wrapper to handle a sequence of {@link AmountFee}, from jPOS-CMF DE-046
+ *
+ * @see AmountFee
+ */
+public class AmountFeesWrapper extends LinkedList<AmountFee> {
+
+    public AmountFeesWrapper() {
+        super();
+    }
+
+    public AmountFeesWrapper(String data) {
+        super();
+        if (data.length() % AmountFee.SERIALIZED_DATA_LENGTH != 0)
+            throw new IllegalArgumentException("Invalid length");
+
+        for (int i = 0; i < data.length(); ) {
+            add(new AmountFee(data.substring(i, i += AmountFee.SERIALIZED_DATA_LENGTH)));
+        }
+    }
+
+    public String serialize() {
+        return stream().map(AmountFee::serialize).collect(Collectors.joining());
+    }
+}

--- a/modules/cmf/src/main/java/org/jpos/cmf/AmountType.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/AmountType.java
@@ -1,0 +1,117 @@
+package org.jpos.cmf;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * See jPOS-CMF.pdf DE-054 <br>
+ * Some extra entries are based on ISO-8583:2003
+ */
+public enum AmountType {
+    ISO_RESERVED("00"),
+
+    // Account related balances
+    ACCOUNT_LEDGER_CURRENT_BALANCE("01"),
+    ACCOUNT_AVAILABLE_BALANCE("02"),
+    AMOUNT_OWING("03"),
+    AMOUNT_DUE("04"),
+    ACCOUNT_AVAILABLE_CREDIT("05"),
+    UNKNOWN("06"),
+    DESTINATION_ACCOUNT_LEDGER_BALANCE("07"),
+    DESTINATION_ACCOUNT_AVAILABLE_BALANCE("08"),
+    CREDIT_LINE("09"),
+    AMOUNT_ON_HOLD("10"),
+
+    // 2x - Card related amounts
+    AMOUNT_REMAINING_THIS_CYCLE("20"),
+
+    // 4x - Transaction related amounts
+    AMOUNT_CASH("40"),
+    AMOUNT_GOODS_AND_SERVICES("41"),
+    AMOUNT_SURCHARGE("42"),
+
+    // 5x - Electronic benefit amounts
+    BEGINNING_BALANCE("50"),
+    PRE_AUTH_AMOUNT("51"),
+
+    // custom CMF
+    GRATUITY("80"),
+    AMOUNT_TAXABLE("81"),
+
+
+    // PRIVATE RESERVED
+    PRIVATE_RESERVED_1S("1S"),
+    PRIVATE_RESERVED_1T("1T"),
+    PRIVATE_RESERVED_1U("1U"),
+    PRIVATE_RESERVED_1V("1V"),
+    PRIVATE_RESERVED_1W("1W"),
+    PRIVATE_RESERVED_1X("1X"),
+    PRIVATE_RESERVED_1Y("1Y"),
+    PRIVATE_RESERVED_1Z("1Z"),
+
+    PRIVATE_RESERVED_2S("2S"),
+    PRIVATE_RESERVED_2T("2T"),
+    PRIVATE_RESERVED_2U("2U"),
+    PRIVATE_RESERVED_2V("2V"),
+    PRIVATE_RESERVED_2W("2W"),
+    PRIVATE_RESERVED_2X("2X"),
+    PRIVATE_RESERVED_2Y("2Y"),
+    PRIVATE_RESERVED_2Z("2Z"),
+
+    PRIVATE_RESERVED_3S("3S"),
+    PRIVATE_RESERVED_3T("3T"),
+    PRIVATE_RESERVED_3U("3U"),
+    PRIVATE_RESERVED_3V("3V"),
+    PRIVATE_RESERVED_3W("3W"),
+    PRIVATE_RESERVED_3X("3X"),
+    PRIVATE_RESERVED_3Y("3Y"),
+    PRIVATE_RESERVED_3Z("3Z"),
+
+    PRIVATE_RESERVED_4S("4S"),
+    PRIVATE_RESERVED_4T("4T"),
+    PRIVATE_RESERVED_4U("4U"),
+    PRIVATE_RESERVED_4V("4V"),
+    PRIVATE_RESERVED_4W("4W"),
+    PRIVATE_RESERVED_4X("4X"),
+    PRIVATE_RESERVED_4Y("4Y"),
+    PRIVATE_RESERVED_4Z("4Z"),
+
+    PRIVATE_RESERVED_5S("5S"),
+    PRIVATE_RESERVED_5T("5T"),
+    PRIVATE_RESERVED_5U("5U"),
+    PRIVATE_RESERVED_5V("5V"),
+    PRIVATE_RESERVED_5W("5W"),
+    PRIVATE_RESERVED_5X("5X"),
+    PRIVATE_RESERVED_5Y("5Y"),
+    PRIVATE_RESERVED_5Z("5Z"),
+    ;
+
+    private static final Map<String, AmountType> byCode = new HashMap<>();
+    static {
+        for (AmountType t : values()){
+            byCode.put(t.code, t);
+        }
+    }
+
+    private final String code;
+
+    AmountType(String code) {
+        this.code = code;
+    }
+
+    @Override
+    public String toString() {
+        return code;
+    }
+    public String getCode() {
+        return code;
+    }
+
+    public static AmountType fromCode(String code) {
+        Objects.requireNonNull(code);
+        AmountType ret = byCode.get(code.toUpperCase());
+        if (ret == null) throw new IllegalArgumentException("Invalid amount type: " + code);
+        return ret;
+    }
+}

--- a/modules/cmf/src/main/java/org/jpos/cmf/CMFAmount.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/CMFAmount.java
@@ -18,6 +18,10 @@ import java.util.Objects;
  * In jPOS-CMF, these are mostly used to represent fees such as those in DE-046
  * </p>
  *
+ * <p><b>ATTN:</b>  The constructors in this class don't check the length in digits of the raw amount.
+ * It's your responsibility to make sure that, when constructing, and then serializing with
+ *  {@link #serialize(boolean, int)}, that the lengths are in accordance and what you need.
+ * </p>
  * <p><b>NOTE:</b>This class does not handle additional amounts (DE-054).
  * For that, use {@link AdditionalAmount} and {@link AdditionalAmountsWrapper}.
  * </p>

--- a/modules/cmf/src/main/java/org/jpos/cmf/CMFAmount.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/CMFAmount.java
@@ -1,5 +1,6 @@
 package org.jpos.cmf;
 
+import org.apache.commons.lang3.BitField;
 import org.jpos.iso.ISOCurrency;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOUtil;
@@ -55,13 +56,22 @@ public class CMFAmount {
      * @param sign 'C' for credit, 'D' for debit
      * @param currency currency code
      * @param minorUnit decimal position.
-     * @param amount Amount as string, unscaled
+     * @param amount Amount as string, unscaled, absolute value
+     *
+     * @throws IllegalArgumentException if uppercase sign is not 'C' or 'D'
+     * @throws IllegalArgumentException if amount includes a sign and parses as negative
      */
     public CMFAmount(char sign, String currency, int minorUnit, String amount) {
         sign = Character.toUpperCase(sign);
-        if (sign != 'D' && sign != 'C') throw  new IllegalArgumentException("invalid sign: " + sign);
-        BigDecimal value = new BigDecimal(new BigInteger(amount), minorUnit);
-        this.amount = (sign == 'D') ? value.negate() : value; //no need to check for null
+        if (sign != 'D' && sign != 'C')
+            throw  new IllegalArgumentException("Invalid sign: " + sign);
+
+        BigInteger amt= new BigInteger(amount);
+        if (amt.compareTo(BigInteger.ZERO) < 0)
+            throw new IllegalArgumentException("Amount string negative; must be given as absolute value: " + amount);
+
+        BigDecimal value = new BigDecimal(amt, minorUnit);
+        this.amount = (sign == 'D') ? value.negate() : value;   //no need to check for null
         setCurrency(currency);
     }
 

--- a/modules/cmf/src/main/java/org/jpos/cmf/CMFAmount.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/CMFAmount.java
@@ -28,7 +28,6 @@ public class CMFAmount {
     protected String currency;
     protected BigDecimal amount;
 
-
     public CMFAmount(BigDecimal amount, String currency) {
         setAmount(amount);
         setCurrency(currency);
@@ -65,7 +64,6 @@ public class CMFAmount {
         this.amount = (sign == 'D') ? value.negate() : value; //no need to check for null
         setCurrency(currency);
     }
-
 
 
     /**

--- a/modules/cmf/src/main/java/org/jpos/cmf/CMFAmount.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/CMFAmount.java
@@ -1,0 +1,159 @@
+package org.jpos.cmf;
+
+import org.jpos.iso.ISOCurrency;
+import org.jpos.iso.ISOException;
+import org.jpos.iso.ISOUtil;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Objects;
+
+/**
+ * This class handles amounts for certain fields in the jPOS-CMF spec that include a currency and minor unit before the amount.<br>
+ *
+ * <p>
+ * The value may be signed or unsigned.
+ * When signed, the string will be prefixed by a 'C' or 'D'.<br>
+ * In jPOS-CMF, these are mostly used to represent fees such as those in DE-046
+ * </p>
+ *
+ * <p><b>NOTE:</b>This class does not handle additional amounts (DE-054).
+ * For that, use {@link AdditionalAmount} and {@link AdditionalAmountsWrapper}.
+ * </p>
+ *
+ */
+public class CMFAmount {
+    public static final int DEFAULT_AMOUNT_LENGTH = 8;              // useful for xn-13 fields (with n8 for the amount part)
+
+    protected String currency;
+    protected BigDecimal amount;
+
+
+    public CMFAmount(BigDecimal amount, String currency) {
+        setAmount(amount);
+        setCurrency(currency);
+    }
+
+    /**
+     * Constructor without minor unit, derives it from currency
+     * @param sign 'C' for credit, 'D' for debit
+     * @param currency currency code
+     * @param amount Amount as string, unscaled
+     */
+    public CMFAmount(char sign, String currency, String amount) throws ISOException {
+        this(sign, currency, ISOCurrency.getCurrency(currency).getDecimals(), amount);
+    }
+
+    /**
+     * Constructor without sign; assumed positive ('C')
+     */
+    public CMFAmount(String currency, int minorUnit, String amount) {
+        this('C', currency, minorUnit, amount);
+    }
+
+    /**
+     *
+     * @param sign 'C' for credit, 'D' for debit
+     * @param currency currency code
+     * @param minorUnit decimal position.
+     * @param amount Amount as string, unscaled
+     */
+    public CMFAmount(char sign, String currency, int minorUnit, String amount) {
+        sign = Character.toUpperCase(sign);
+        if (sign != 'D' && sign != 'C') throw  new IllegalArgumentException("invalid sign: " + sign);
+        BigDecimal value = new BigDecimal(new BigInteger(amount), minorUnit);
+        this.amount = (sign == 'D') ? value.negate() : value; //no need to check for null
+        setCurrency(currency);
+    }
+
+
+
+    /**
+     * Constructor from full CMF string.<br>
+     * It supports amounts with or without sign as the first character ('C' or 'D' prefix),
+     * and expects currency and minor unit parts before the actual amount.<br>
+     * The general syntax is [sign] + currency + minor + amount.<br>
+     * Currency is <code>N3</code>, minor unit <code>N1</code>, and the rest is the amount (usually 8 or 12 digits).<br>
+     *
+     * @param cmfAmount The string representing all the components of the amount
+     * @see #serialize(boolean, int)
+     */
+    public CMFAmount(String cmfAmount) {
+        Objects.requireNonNull(cmfAmount);
+        char sign = 'C';
+        char first = Character.toUpperCase(cmfAmount.charAt(0));
+        if (first == 'C' || first == 'D') {
+            sign = first;
+            cmfAmount = cmfAmount.substring(1);     // consume first character
+        }
+        currency = cmfAmount.substring(0, 3);
+        char minorUnit = cmfAmount.charAt(3);
+        if (minorUnit < '0' || minorUnit > '9') throw new IllegalArgumentException("Bad minor unit: " + minorUnit);
+
+        BigDecimal value = new BigDecimal(new BigInteger(cmfAmount.substring(4)), minorUnit - '0');
+        this.amount = (sign == 'D') ? value.negate() : value;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = Objects.requireNonNull(amount);
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = Objects.requireNonNull(currency);
+    }
+
+    public int getMinorUnit() {
+        return amount.scale();
+    }
+
+    public char getSign() {
+        return amount.signum() < 0 ? 'D' : 'C';
+    }
+
+    /**
+     * Serialize with optional sign, and given length for the amount part.<br>
+     *
+     * The string returned is of the form <code>[C|D] + currency + minor + amount</code>,
+     * where the first character ('C' or 'D') is the sign (for positive or negative, respectively),
+     * the currency format is N3, the minor unit is N1, and the amount is of the given <code>amountLength</code>.
+     *
+     * @param withSign whether to emit the sign character
+     * @param amountLength the length in digits for the amount part
+     * @return The serialized value as a String
+     */
+    public String serialize(boolean withSign, int amountLength){
+        StringBuilder builder = new StringBuilder(13);
+        if (withSign) builder.append(getSign());
+        return builder.append(currency)
+                .append(getMinorUnit())
+                .append(ISOUtil.zeropad(amount.abs().unscaledValue().intValue(), amountLength))
+                .toString();
+    }
+
+    /**
+     *  Serialize with optional sign and DEFAULT_AMOUNT_LENGTH (8)
+     *
+     * @param withSign whether to emit the sign character
+     * @return A string as returned by {@link #serialize(boolean, int)} with the chosen withSign argument, and the default amount length
+     */
+    public String serialize(boolean withSign){
+        return serialize(withSign, DEFAULT_AMOUNT_LENGTH);
+    }
+
+    /**
+     * Serialize with sign and DEFAULT_AMOUNT_LENGTH (8)
+     *
+     * @return A string as returned by {@link #serialize(boolean, int)} with sign and the default amount length
+     */
+    public String serialize() {
+        return serialize(true, DEFAULT_AMOUNT_LENGTH);
+    }
+}

--- a/modules/cmf/src/main/java/org/jpos/cmf/CMFConstants.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/CMFConstants.java
@@ -1,0 +1,34 @@
+package org.jpos.cmf;
+
+public enum CMFConstants {
+    CMF_VERSION("106"),
+    JPF_VERSION("113.2"),
+    JPF_FIRSTNAME( "113.3"),
+    JPF_MIDDLENAME("113.4"),
+    JPF_LASTNAME("113.5"),
+    JPF_LASTNAME2("113.6"),
+    JPF_EMAIL("113.7"),
+    JPF_STATUS("113.8"),
+    JPF_HONORIFIC("113.9"),
+    JPF_GENDER("113.10"),
+    JPF_ADDR1("113.11"),
+    JPF_ADDR2("113.12"),
+    JPF_CITY("113.13"),
+    JPF_STATE("113.14"),
+    JPF_ZIPCODE("113.15"),
+    JPF_COUNTRY("113.16"),
+    JPF_PHONE("113.17"),
+    JPF_NOTES("113.18"),
+    JPF_DATES("113.19"),
+    JPF_ALT_ID("113.20");
+
+    private String value;
+
+    CMFConstants(String value) {
+        this.value = value;
+    }
+    public String value() {
+        return value;
+    }
+}
+

--- a/modules/cmf/src/main/java/org/jpos/cmf/CMFDate.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/CMFDate.java
@@ -1,0 +1,100 @@
+package org.jpos.cmf;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+/**
+ * Util class to parse and format CMF dates and datetimes.<br>
+ *
+ * This class uses the new java time API since its formatters are thread safe.<br>
+ *
+ * Null parameters are preserved in order to avoid unnecessary null checks before calling the function.<br>
+ *
+ * Unless indicated otherwise, conversions are done using {@link ZoneId#systemDefault()}
+ */
+public class CMFDate {
+    //TODO: implement formatting methods
+
+    public static final DateTimeFormatter CMF_DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+    public static final DateTimeFormatter CMF_DATETIME = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    /**
+     * Parse a CMF formatted date as yyyyMMdd to {@link LocalDate}
+     *
+     * @param cmfDateString content to parse
+     * @return parsed {@link LocalDate}
+     */
+    public static LocalDate parseLocalDate(String cmfDateString) {
+        return cmfDateString == null ? null : LocalDate.parse(cmfDateString, CMF_DATE);
+    }
+
+    /**
+     * Utilitarian method that converts a {@link LocalDate} instance to {@link Date}
+     * @param dateToConvert {@link LocalDate} to convert
+     * @return converted {@link Date}
+     */
+    public static Date toDate(LocalDate dateToConvert) {
+        return dateToConvert == null ? null :
+                java.util.Date.from(dateToConvert.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    /**
+     * Parse a CMF formatted date as yyyyMMdd to {@link Date}
+     *
+     * @param cmfDateString content to parse
+     * @return parsed {@link Date}
+     */
+    public static Date parseDate(String cmfDateString) {
+        return cmfDateString == null ? null : toDate(parseLocalDate(cmfDateString));
+    }
+
+    public static String format(LocalDate date) {
+        return date == null ? null : CMF_DATE.format(date);
+    }
+
+    public static LocalDate toLocalDate(Date date) {
+        return date == null ? null : date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+    }
+
+    public static String formatDate(Date date) {
+        return date == null ? null : format(toLocalDate(date));
+    }
+
+    /**
+     * Parse a CMF formatted date/time as yyyyMMddHHmmss to {@link LocalDateTime}
+     * @param cmfDateString content to parse
+     * @return parsed {@link LocalDateTime}
+     */
+    public static LocalDateTime parseLocalDateTime(String cmfDateString) {
+        return cmfDateString == null ? null : LocalDateTime.parse(cmfDateString, CMF_DATETIME);
+    }
+
+    public static Date toDate(LocalDateTime dateTimeToConvert) {
+        return dateTimeToConvert == null ? null
+                : java.util.Date.from(dateTimeToConvert.atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    /**
+     * Parse a CMF formatted date/time as yyyyMMddHHmmss to {@link Date}
+     * @param cmfDateString content to parse
+     * @return parsed {@link Date}
+     */
+    public static Date parseDateTime(String cmfDateString) {
+        return cmfDateString == null ? null : toDate(parseLocalDate(cmfDateString));
+    }
+
+    public static String format(LocalDateTime dateTime) {
+        return dateTime == null ? null : CMF_DATETIME.format(dateTime);
+    }
+
+    public static LocalDateTime toLocalDateTime(Date date) {
+        return date == null ? null : date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+    }
+    public static String formatDateTime(Date date) {
+        return date == null ? null : format(toLocalDateTime(date));
+    }
+
+}

--- a/modules/cmf/src/main/java/org/jpos/cmf/FeeType.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/FeeType.java
@@ -1,0 +1,85 @@
+package org.jpos.cmf;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * See jPOS-CMF.pdf DE-046 <br>
+ * Some extra entries are based on ISO-8583:2003
+ */
+public enum FeeType {
+    TRANSACTION_FEE("00"),
+    TRANSACTION_PROCESSING_FEE("01"),
+    FEE_COLLECTION_FEE("02"),
+    LOST_CARD_REPORT_FEE("06"),   // lost/stolen
+    ACQUIRER_FEE("07"),
+    INVALID_CHARGEBACK_FEE("09"),
+    CURRENCY_CONVERSION_FEE("15"),
+
+    // Reserved for private use
+    PRIVATE_70("70"),
+    PRIVATE_71("71"),
+    PRIVATE_72("72"),
+    PRIVATE_73("73"),
+    PRIVATE_74("74"),
+    PRIVATE_75("75"),
+    PRIVATE_76("76"),
+    PRIVATE_77("77"),
+    PRIVATE_78("78"),
+    PRIVATE_79("79"),
+
+    PRIVATE_80("80"),
+    PRIVATE_81("81"),
+    PRIVATE_82("82"),
+    PRIVATE_83("83"),
+    PRIVATE_84("84"),
+    PRIVATE_85("85"),
+    PRIVATE_86("86"),
+    PRIVATE_87("87"),
+    PRIVATE_88("88"),
+    PRIVATE_89("89"),
+
+    PRIVATE_90("90"),
+    PRIVATE_91("91"),
+    PRIVATE_92("92"),
+    PRIVATE_93("93"),
+    PRIVATE_94("94"),
+    PRIVATE_95("95"),
+    PRIVATE_96("96"),
+    PRIVATE_97("97"),
+    PRIVATE_98("98"),
+    PRIVATE_99("99"),
+    ;
+
+
+    private static final Map<String, FeeType> byCode = new HashMap<>();
+    static {
+        for (FeeType t : values()){
+            byCode.put(t.code, t);
+        }
+    }
+
+
+    private final String code;
+
+    FeeType(String code) {
+        this.code = code;
+    }
+
+    @Override
+    public String toString() {
+        return code;
+    }
+    public String getCode() {
+        return code;
+    }
+
+    public static FeeType fromCode(String code) {
+        Objects.requireNonNull(code);
+        FeeType ret = byCode.get(code);
+        if (ret == null) throw new IllegalArgumentException("Unknown fee type: " + code);
+        return ret;
+    }
+
+}

--- a/modules/cmf/src/main/java/org/jpos/cmf/OriginalDataElementsWrapper.java
+++ b/modules/cmf/src/main/java/org/jpos/cmf/OriginalDataElementsWrapper.java
@@ -1,0 +1,119 @@
+package org.jpos.cmf;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DateUtils;
+import org.jpos.iso.ISODate;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * Handles original data elements field content - DE-056
+ */
+public final class OriginalDataElementsWrapper {
+
+    private static final int MAX_FIELD_LENGTH = 41;
+
+    private String originalMTI;
+    private int originalSTAN;
+    private Date originalLocalDate;
+    private String originalAcquiringInstCode;
+
+    public OriginalDataElementsWrapper() { }
+
+    public OriginalDataElementsWrapper(String fieldValue) {
+
+        Objects.requireNonNull(fieldValue);
+
+        if (fieldValue.length() > MAX_FIELD_LENGTH)
+            throw new IllegalArgumentException("Invalid length");
+
+        parse(fieldValue);
+    }
+
+    private void parse(String fieldValue) {
+
+        try {
+
+            setOriginalMTI(fieldValue.substring(0, 4));
+            setOriginalSTAN(Integer.valueOf(fieldValue.substring(4, 16)));
+            setOriginalLocalDate(DateUtils.parseDate(fieldValue.substring(16, 30), "yyyyMMddHHmmss"));
+            setOriginalAcquiringInstCode(fieldValue.substring(30));
+        }
+        catch (Exception e) {
+
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public String serialize() {
+
+        StringBuilder r = new StringBuilder();
+
+        if (StringUtils.isNotBlank(getOriginalMTI()))
+            r.append(StringUtils.leftPad(getOriginalMTI(), 4, '0'));
+        else
+            r.append("0000");
+
+        r.append(StringUtils.leftPad(Integer.toString(getOriginalSTAN()), 12, '0'));
+
+        if (getOriginalLocalDate() != null)
+            r.append(ISODate.formatDate(getOriginalLocalDate(), "yyyyMMddHHmmss"));
+        else
+            r.append(StringUtils.repeat('0', 14));
+
+        if (StringUtils.isNotBlank(getOriginalAcquiringInstCode()))
+            r.append(getOriginalAcquiringInstCode());
+
+        return r.toString();
+    }
+
+    public String getOriginalMTI() {
+        return originalMTI;
+    }
+
+    public void setOriginalMTI(String originalMTI) {
+
+        if (StringUtils.isBlank(originalMTI))
+            throw new NullPointerException("originalMTI cannot be null or empty");
+
+        if (originalMTI.length() != 4)
+            throw new IllegalArgumentException("originalMTI length is invalid");
+
+        this.originalMTI = originalMTI;
+    }
+
+    public int getOriginalSTAN() {
+        return originalSTAN;
+    }
+
+    public void setOriginalSTAN(int originalSTAN) {
+
+        if (originalSTAN < 0)
+            throw new IllegalArgumentException("originalSTAN must be a positive number");
+
+        this.originalSTAN = originalSTAN;
+    }
+
+    public Date getOriginalLocalDate() {
+        return originalLocalDate;
+    }
+
+    public void setOriginalLocalDate(Date originalLocalDate) {
+        this.originalLocalDate = originalLocalDate;
+    }
+
+    public String getOriginalAcquiringInstCode() {
+        return originalAcquiringInstCode;
+    }
+
+    public void setOriginalAcquiringInstCode(String originalAcquiringInstCode) {
+
+        Objects.requireNonNull(originalAcquiringInstCode);
+
+        if (originalAcquiringInstCode.length() > 11)
+            throw new IllegalArgumentException("Invalid length");
+
+        this.originalAcquiringInstCode = originalAcquiringInstCode;
+    }
+}

--- a/modules/cmf/src/test/java/org/jpos/cmf/AdditionalAmountsWrapperTest.java
+++ b/modules/cmf/src/test/java/org/jpos/cmf/AdditionalAmountsWrapperTest.java
@@ -1,12 +1,11 @@
 package org.jpos.cmf;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public final class AdditionalAmountsWrapperTest {
@@ -36,4 +35,113 @@ public final class AdditionalAmountsWrapperTest {
         assertNotNull(wrapper.getFirstByAmountType(AmountType.AMOUNT_CASH));
         assertNull(wrapper.getFirstByAmountType(AmountType.AMOUNT_REMAINING_THIS_CYCLE));
     }
+
+
+    @Test
+    public void testParseInvalidLengthData() {
+        String sample = "00028582C00000010000000018582C0000001000";
+        assertThrows(IllegalArgumentException.class, () -> AdditionalAmountsWrapper.parse(sample));
+    }
+
+   @Test
+   public void testSuccessfulParse() {
+       String sample =  "00" + "02" + "858"+"2" + "C"+"000000100000" +
+                        "00" + "01" + "858"+"2" + "C"+"000000100000";
+
+       AdditionalAmountsWrapper wrapper = AdditionalAmountsWrapper.parse(sample);
+       assertEquals(2, wrapper.size());
+   }
+
+   @Test
+   public void testParseAndSerialize() {
+       String sample =  "00" + "02" + "840"+"2" + "C"+"000000100000" +
+                        "00" + "01" + "858"+"2" + "C"+"000000100000";
+
+       AdditionalAmountsWrapper wrapper = AdditionalAmountsWrapper.parse(sample);
+       assertEquals(sample, wrapper.serialize());
+   }
+
+   @Test
+   public void testParseAndSerializeOneItem() {
+
+       String sample = "00" + "01" + "858"+"2" + "C"+"000000100000";
+
+       AdditionalAmountsWrapper wrapper = AdditionalAmountsWrapper.parse(sample);
+
+       assertEquals(1, wrapper.size());
+       assertEquals(sample, wrapper.serialize());
+   }
+
+   @Test
+   public void test_listByAmountType() {
+       AdditionalAmountsWrapper wrapper = new AdditionalAmountsWrapper();
+
+       wrapper.add(new AdditionalAmount("00", new BigDecimal("200.00"), "840", AmountType.AMOUNT_SURCHARGE, 1));
+       wrapper.add(new AdditionalAmount("00", new BigDecimal("300.00"), "840", AmountType.AMOUNT_CASH, 1));
+       wrapper.add(new AdditionalAmount("30", new BigDecimal("400.00"), "840", AmountType.AMOUNT_SURCHARGE, 1));
+
+       List<AdditionalAmount> amounts = wrapper.listByAmountType(AmountType.AMOUNT_SURCHARGE);
+
+       assertNotNull(amounts);
+       assertEquals(2, amounts.size());
+   }
+
+   @Test
+   public void test_listByTypes_WithAccountAndAmountTypes() {
+       AdditionalAmountsWrapper wrapper = new AdditionalAmountsWrapper();
+
+       wrapper.add(new AdditionalAmount("00", new BigDecimal("200.00"), "840", AmountType.AMOUNT_SURCHARGE, 1));
+       wrapper.add(new AdditionalAmount("00", new BigDecimal("300.00"), "840", AmountType.AMOUNT_CASH, 1));
+       wrapper.add(new AdditionalAmount("30", new BigDecimal("400.00"), "840", AmountType.AMOUNT_SURCHARGE, 1));
+
+       List<AdditionalAmount> amounts = wrapper.listByTypes("00", AmountType.AMOUNT_SURCHARGE);
+       assertNotNull(amounts);
+       assertEquals(1, amounts.size());
+   }
+
+   @Test
+   public void test_listByTypes_WithNullAccountType() {
+       AdditionalAmountsWrapper wrapper = new AdditionalAmountsWrapper();
+
+       wrapper.add(new AdditionalAmount("00", new BigDecimal("200.00"), "840", AmountType.AMOUNT_SURCHARGE, 1));
+       wrapper.add(new AdditionalAmount("00", new BigDecimal("300.00"), "840", AmountType.AMOUNT_CASH, 1));
+       wrapper.add(new AdditionalAmount("30", new BigDecimal("400.00"), "840", AmountType.AMOUNT_SURCHARGE, 1));
+
+       List<AdditionalAmount> amounts = wrapper.listByTypes(null, AmountType.AMOUNT_SURCHARGE);
+       assertNotNull(amounts);
+       assertEquals(2, amounts.size());
+   }
+
+
+
+   @Test
+   public void test_getFirstByAmountType() {
+       AdditionalAmountsWrapper wrapper = new AdditionalAmountsWrapper();
+
+       wrapper.add(new AdditionalAmount("00", new BigDecimal("200.00"), "840", AmountType.AMOUNT_SURCHARGE, 1));
+       wrapper.add(new AdditionalAmount("00", new BigDecimal("300.00"), "840", AmountType.AMOUNT_CASH, 1));
+       wrapper.add(new AdditionalAmount("30", new BigDecimal("400.00"), "840", AmountType.AMOUNT_SURCHARGE, 1));
+
+       AdditionalAmount amount = wrapper.getFirstByAmountType(AmountType.AMOUNT_SURCHARGE);
+
+       assertNotNull(amount);
+       assertEquals(new BigDecimal("200.00"), amount.getAmount());
+       assertEquals("00", amount.getAccountType());
+   }
+
+   @Test
+   public void test_containsAmountType() {
+       AdditionalAmountsWrapper wrapper = new AdditionalAmountsWrapper();
+
+       wrapper.add(new AdditionalAmount("00", new BigDecimal("200.00"), "840", AmountType.AMOUNT_SURCHARGE, 1));
+       wrapper.add(new AdditionalAmount("00", new BigDecimal("300.00"), "840", AmountType.AMOUNT_CASH, 1));
+
+       assertTrue(wrapper.containsAmountType(AmountType.AMOUNT_SURCHARGE));
+       assertTrue(wrapper.containsAmountType(AmountType.AMOUNT_CASH));
+       assertFalse(wrapper.containsAmountType(AmountType.AMOUNT_REMAINING_THIS_CYCLE));
+   }
+
 }
+
+
+

--- a/modules/cmf/src/test/java/org/jpos/cmf/AdditionalAmountsWrapperTest.java
+++ b/modules/cmf/src/test/java/org/jpos/cmf/AdditionalAmountsWrapperTest.java
@@ -1,0 +1,39 @@
+package org.jpos.cmf;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+
+
+public final class AdditionalAmountsWrapperTest {
+
+    @Test
+    public void test_contains_amountType() {
+
+        AdditionalAmountsWrapper wrapper = new AdditionalAmountsWrapper();
+
+        wrapper.add(new AdditionalAmount("30", new BigDecimal("10.00"), "858", AmountType.AMOUNT_CASH, 1));
+        wrapper.add(new AdditionalAmount("30", new BigDecimal("12.00"), "858", AmountType.AMOUNT_TAXABLE, 1));
+
+        assertTrue(wrapper.containsAmountType(AmountType.AMOUNT_TAXABLE));
+        assertTrue(wrapper.containsAmountType(AmountType.AMOUNT_CASH));
+        assertFalse(wrapper.containsAmountType(AmountType.AMOUNT_REMAINING_THIS_CYCLE));
+    }
+
+    @Test
+    public void test_get_by_amountType() {
+
+        AdditionalAmountsWrapper wrapper = new AdditionalAmountsWrapper();
+
+        wrapper.add(new AdditionalAmount("30", new BigDecimal("10.00"), "858", AmountType.AMOUNT_CASH, 1));
+        wrapper.add(new AdditionalAmount("30", new BigDecimal("12.00"), "858", AmountType.AMOUNT_TAXABLE, 1));
+
+        assertNotNull(wrapper.getFirstByAmountType(AmountType.AMOUNT_TAXABLE));
+        assertNotNull(wrapper.getFirstByAmountType(AmountType.AMOUNT_CASH));
+        assertNull(wrapper.getFirstByAmountType(AmountType.AMOUNT_REMAINING_THIS_CYCLE));
+    }
+}

--- a/modules/cmf/src/test/java/org/jpos/cmf/AmountFeeTest.java
+++ b/modules/cmf/src/test/java/org/jpos/cmf/AmountFeeTest.java
@@ -1,0 +1,57 @@
+package org.jpos.cmf;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public final class AmountFeeTest
+{
+    @Test
+    public void constructorFullWithStringConversionRate() {
+        AmountFee af1 = new AmountFee(FeeType.ACQUIRER_FEE,
+                                      new CMFAmount(new BigDecimal("20.00"),  "858"), // fee
+                                      new CMFAmount(new BigDecimal( "0.50"),  "840"), // settlement fee
+                                      "3"+"0000025");                                 // 0000.025
+        AmountFee af2 = new AmountFee(FeeType.ACQUIRER_FEE,
+                                      new CMFAmount(new BigDecimal("20.00"),  "858"), // fee
+                                      new CMFAmount(new BigDecimal( "0.50"),  "840"), // settlement fee
+                                      "4"+"0000250");                                 // 000.0250
+
+        assertTrue(0 == af1.getConversionRate().compareTo(new BigDecimal("0000.025")), "Conversion rate doesn't match");
+        assertTrue(0 == af2.getConversionRate().compareTo(new BigDecimal("000.0250")), "Conversion rate doesn't match");
+    }
+
+    @Test
+    public void constructorFullWithBigDecimalConversionRate() {
+        AmountFee af3 = new AmountFee(FeeType.ACQUIRER_FEE,
+                                      new CMFAmount(new BigDecimal("20.00"),  "858"), // fee
+                                      new CMFAmount(new BigDecimal( "0.50"),  "840"), // settlement fee
+                                      new BigDecimal("5.0002508"));
+        assertTrue(0 == af3.getConversionRate().compareTo(new BigDecimal("5.000251"))); // must round to precision 7
+    }
+
+
+    @Test
+    public void constructorString() {
+        String amtFee = FeeType.ACQUIRER_FEE.getCode() +        // (n2)
+                        "C" + "858" + "2" + "00002000" +        // fee (x+n12)
+                        "6" + "5000251" +                       // conversion rate (n8)
+                        "C" + "840" + "2" + "00000050";         // settlement fee (x+n12)
+        AmountFee af = new AmountFee(amtFee);
+        assertEquals(af.serialize(), amtFee);
+    }
+
+    @Test
+    public void constructorStringShouldFailForLength() {
+        String amtFee = /*FeeType.ACQUIRER_FEE.getCode() +*/    // (n2) Forgot the fee type!
+                        "C" + "858" + "2" + "00002000" +        // fee (x+n12)
+                        "6" + "5000251" +                       // conversion rate (n8)
+                        "C" + "840" + "2" + "00000050";         // settlement fee (x+n12)
+
+        assertThrows(IllegalArgumentException.class, () -> new AmountFee(amtFee));
+    }
+
+}

--- a/modules/cmf/src/test/java/org/jpos/cmf/CMFAmountTest.java
+++ b/modules/cmf/src/test/java/org/jpos/cmf/CMFAmountTest.java
@@ -1,0 +1,71 @@
+package org.jpos.cmf;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public final class CMFAmountTest
+{
+    @Test
+    public void constructorFromStringWithSign() {
+        CMFAmount am = new CMFAmount("D" + "840" + "2" + "12345678");       // negative!
+        assertEquals(am.getSign(), 'D');
+        assertEquals(am.getCurrency(), "840");
+        assertEquals(am.getMinorUnit(), 2);
+
+        BigDecimal bdAmt= am.getAmount();
+        BigDecimal expectedBdAmt= new BigDecimal("123456.78").negate();     // negative!
+
+        assertEquals(0, bdAmt.compareTo(expectedBdAmt), "Expected amount '"+expectedBdAmt+"' but got '"+bdAmt+"'");
+    }
+
+    @Test
+    public void constructorFromStringWithoutSign() {
+        CMFAmount am = new CMFAmount("840" + "2" + "12345678");
+        assertEquals(am.getSign(), 'C');                                    // no sign, asssumes positive
+        assertEquals(am.getCurrency(), "840");
+        assertEquals(am.getMinorUnit(), 2);
+
+        BigDecimal bdAmt= am.getAmount();
+        BigDecimal expectedBdAmt= new BigDecimal("123456.78");              // no sign, asssumes positive
+
+        assertEquals(0, bdAmt.compareTo(expectedBdAmt), "Expected amount '"+expectedBdAmt+"' but got '"+bdAmt+"'");
+    }
+
+    @Test
+    public void constructorFromStringWithSign_SerializeDefault() {
+        String inpString = "D" + "840" + "2" +     "12345678";
+        String outString = "D" + "840" + "2" +     "12345678";
+        CMFAmount am = new CMFAmount(inpString);
+        assertEquals(am.serialize(), outString);
+    }
+
+    @Test
+    public void constructorFromStringWithSign_Serialize12() {
+        String inpString = "D" + "840" + "2" +     "12345678";
+        String outString = "D" + "840" + "2" + "000012345678";
+        CMFAmount am = new CMFAmount(inpString);
+        assertEquals(am.serialize(true, 12), outString);
+    }
+
+    @Test
+    public void constructorFromStringWithoutSign_SerializeDefault() {
+        String inpString =       "840" + "2" + "12345678";
+        String outString = "C" + "840" + "2" + "12345678";
+        CMFAmount am = new CMFAmount(inpString);
+        assertEquals(am.serialize(), outString);
+    }
+
+    @Test
+    public void constructorFromStringWithSign_Serialize12WithoutSign() {
+        String inpString = "D" + "840" + "2" +     "12345678";  // negative
+        String outString =       "840" + "2" + "000012345678";
+        CMFAmount am = new CMFAmount(inpString);
+        assertEquals(am.serialize(false, 12), outString);       // without sign (even though it was negative... just to test)
+    }
+
+
+}

--- a/modules/txn/src/main/java/org/jpos/transaction/TxnId.java
+++ b/modules/txn/src/main/java/org/jpos/transaction/TxnId.java
@@ -22,6 +22,9 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import java.io.File;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -34,6 +37,7 @@ public class TxnId {
     private static final long NMUL = 100000L;
     private static final long MAX_VALUE = Long.parseLong("zzzzzzzzzzzz", 36);
     private static Pattern pattern = Pattern.compile("^([\\d]{3})-([\\d]{3})-([\\d]{5})-([\\d]{3})-([\\d]{5})$");
+    private static ZoneId UTC = ZoneId.of("UTC");
 
     private TxnId() {
         super();
@@ -138,6 +142,13 @@ public class TxnId {
             dt = dt.toDateTime(DateTimeZone.UTC);
 
         return id.init (dt.getYear()-2000, dt.getDayOfYear(), dt.getSecondOfDay(), node, transactionId);
+    }
+
+    public static TxnId create (Instant instant, int node, long transactionId) {
+        TxnId id = new TxnId();
+        ZonedDateTime utc = instant.atZone(UTC);
+        int seconds = (utc.getHour() * 3600) + (utc.getMinute()*60) + utc.getSecond();
+        return id.init (utc.getYear()-2000, utc.getDayOfYear(), seconds, node, transactionId);
     }
 
     /**

--- a/modules/txn/src/test/java/org/jpos/transaction/TxnIdTest.java
+++ b/modules/txn/src/test/java/org/jpos/transaction/TxnIdTest.java
@@ -21,6 +21,8 @@ package org.jpos.transaction;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -75,5 +77,14 @@ public class TxnIdTest {
         assertEquals(txnId2, txnId3);
         assertEquals(txnId2.toString(), txnId3.toString());
         assertEquals(12, txnId.toRrn().length());
+    }
+
+    @Test
+    public void testJodaTimeCompatibility() {
+        DateTime now = DateTime.now();
+        Instant instant = now.toDate().toInstant();
+        TxnId txnId1 = TxnId.create(now, 0, 1L);
+        TxnId txnId2 = TxnId.create(instant, 0, 1L);
+        assertEquals(txnId1, txnId2);
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include ':modules:core',
+        ':modules:cmf',
         ':modules:freemarker-decorator',
         ':modules:syslog',
         ':modules:sysconfig',


### PR DESCRIPTION
#### Comentarios Generales:

- Arranqué con lo que había en `tr-mastercard` y después fui archivo por archivo comparando las diffs con todos los proyectos en mi filesystem donde aparecía ese `*.java`.  Lo que salió fue la combinación genética mejorada (espero!) de todas esas versiones

- Se puede haber roto la compatibilidad con otras versiones que están embebidas en cada proyecto (algún renaming de método y cosas así). Pero, como varios proyectos tenían sus propias versiones incompatibles, en realidad no rompemos nada sino que este es el nuevo y público y el MAS MEJOR del mundo mundial, y el que lo quiera adoptar que lo haga, y el que no que siga usando su vieja versión privada.

- Faltan tests (especialmente voy a integrar en `AdditionalAmountsWrapper`  varios que estan en otros proyectos como 3pea, nibss que son mucho más completos aunque más viejos)

- Agregué varios javadocs, que estaba muy pobre en ese sentido, especialmente en lugares donde creo que ayuda a definir el scope o contexto de uso de la clase método (casi como un disclaimer, por ej. en `CMFAmount` que tiene un nombre demasiado genérico, pero explicita que no se te ocurra usarlo para los additional amounts). Igual se podrían mejorar los javadocs.

#### Comentarios de algunas clases que lo ameritan:

- `enum FeeType`
    - Agregué algunos casos interesantes tomados de v2003 
    - Algunas versiones tenían  `PRIVATEXX`  con `XX` en el rango `00-29` pero mapeaban los codes `70 - 99`. Me parecía medio inconsistente así que los renombré desde `PRIVATE_70` a `PRIVATE_99` para que sea más claro el código interno al que nos referimos.
    - Uniformicé el API y la impl junto con `enum AmountType` para que ambos usen un `code` y un `fromCode()` (en vez de `fromString()` como hacía este) y que usen un map interno ya armado con el mapeo para que en `fromString()` no haya que recorrer todos los casos

- `enum AmountType` Llevó acaloradas discusiones, pero básicamente quedó así
    - Algunos casos agregados desde v2003
    - v2003 reserva montones de rangos alfanuméricos para casos ISO Reserved, National Reserved, y Private reserved.  Agregué solo los private con nomenclatura `PRIVATE_RESERVED_XX`  (con `XX` siguiendo el código alfanum). Los ISO Reserved nunca en la vida los van a usar para nada. Y los National, dudo ampliamente. Si alguien precisa custom amount types, que use uno de los PRIVATE.  El que sea un enum permite en el custom code hasta hacer un "alias" del enum con un nombre más lindo.

- `CMFConstants`  No sufrió cambios. Simplemente que hay versiones básicamente idénticas en paquetes `*.cmf`, `*.jcard` y `*.rest` según el proyecto, lo cual ahora sería medio redundante.

- `CMFAmount`
    -  queda con su formato de **signo (opcional) antes de curr+minor+amount**.  Hay ambigüedades al respecto según las distintas specs y jPOS-CMF tampoco lo aclara mucho. De hecho en v2003 no es explícito (no dan ni un ejemplo) sino que se infiere por otras partes del texto.  Como hablábamos con Andrés, esto es distinto al `AdditionalAmount` donde el signo aparece entre currency y amount (y ese sí está explícito en CMF, y es lo más estándar en muchas specs que encontré)
    - Al parsear, para ver si tiene signo o no, ya no se basa en que si el `length > 12` sino efectivamente mira el primer char a ver si es `C` o `D` que es más robusto 
   - OPINABLE: El parseo acepta `c` y `d` en minúscula para el signo. He visto casos así in the wild, aunque no lo especifica CMF, pero no hace daño aceptarlo (al momento de serializar siempre salen en mayúscula)
    - Hay una nueva versión de `serialize()` que acepta el length para el amount. Por defecto es 8, que son las mayorías de los casos para *fee*, pero se le puede pasar un 12 que sirve para los casos que v2003 llama `xn 17`

- `AmountFee`otro muy discutido con aquello del rounding.
    -  dejé el `MathContext` con prcisión de 7 pero le agregué el rounding HALF_EVEN que había en otras versiones de la clase. 
    - En realidad, como ya no acepta un conversion rate `null` en los constructures, pierde un poco de sentido todo eso.
    - Al **parsear** le agregué el correcto manejo (according to specs) del caso `8` y `9` para el decimal point del `conversionRate`
    - Al momento de serializar no tiene ese manejo porque tiene una complejidad con la precisiony el caso `8` que no me dio la cabeza a esa hora para solucionarlo. Igual son casos muy extremos, que alguien use más de 7 posiciones decimales en una conversion rate (ni las bolsas de Wall Street usan tantos decimales!!)
    - Fijarse en los changed files de este PR  https://github.com/barspi/jPOS-EE/pull/1/files#diff-48b1b14d1556532475b3823094a89ce5e5c12107e1cd8989b7209edfe48f2365
    - REVIEW REQUIRED: Hay algunos comments con BBB y/o TODO.  Pueden comentar directamente ahí en las líneas del código a ver si eliminamos ese méto

- `AdditionalAmount`
    - Elimina el manejo de formatos v87 (estamos en el paquete CMF después de todo) que aparecían en algunas versiones de la clase. Si hay que hacer conversiones, que las hagan los converters/adapters correspondientes.
    - Agrega el manejo correcto de minor unit usando el minor de la currency en vez de **hardcoded a 2 posiciones** como hacían algunas versiones.
- `AdditionalAmountsWrapper`
- Es una clase que tenía muchas variantes en su API (métodos para query el campo compuesto).
En alguna variantes el método `getByAmountType()` devolvía un solo caso (el primero), en otras devolvía una lista, etc..
Decidí uniformizar un poco los nombres, a mi gusto, y agregar algunos casos.
- Ahora, el más genérico se llama  `List<AdditionalAmount> listByTypes(String accountType, AmountType amountType)` que creo que queda bien clarito que devuelve una lista y se puede buscar también por `accountType` (porque tal vez no alcance solo con el `amountType` para lo que queremos
- Y luego hay variedades sobre el mismo tema, con nombres que espero sean más claros, y con sendos javadocs explicando todo
- Como dije por ahí, si le rompe la compat a alguien, va a ser muy claro porque no va a compilar, y que lo arreglen y si no que sigan usando su versión vieja :-) 

- `AmountFeesWrapper` no hay mucho misterio pero le voy a agregar esos tests que mencionaba al principio
